### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "CompUnit::Util",
+    "license" : "MIT",
     "perl" : "6.*",
     "version" : "0.6.0",
     "description" : "Utilities for introspecting compunits and re-exporting",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license