### PR TITLE
source-url attribute missing ".git" extension

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,5 +10,5 @@
     },
     "depends" : [],
     "resources" : [],
-    "source-url" : "git://github.com/LLFourn/p6-CompUnit-Util"
+    "source-url" : "git://github.com/LLFourn/p6-CompUnit-Util.git"
 }


### PR DESCRIPTION
The missing ".git" is breaking the travis build of Archive::SimpleZip. See https://travis-ci.org/pmqs/Archive-SimpleZip/jobs/542263527 

Issue first reported against zef in https://github.com/ugexe/zef/issues/302