### PR TITLE
Changes source-utl in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,5 +10,5 @@
     },
     "depends" : [],
     "resources" : [],
-    "source-url" : "git://github.com/LLFourn/p6-CompUnit-Util"
+    "source-url" : "git://github.com/LLFourn/p6-CompUnit-Util.git"
 }


### PR DESCRIPTION
This changes source-url to something zef can make out a retrieval method for.