### PR TITLE
Loosen `all-loaded` test

### DIFF
--- a/t/01-utils.t
+++ b/t/01-utils.t
@@ -11,7 +11,7 @@ ok find-loaded('CompUnit::Util') ~~ CompUnit:D, 'found CompUnit::Util';
 nok find-loaded('Foo'),'find-loaded on non-existent module returns false';
 ok find-loaded('Foo') ~~ Failure:D,'returns Failure';
 
-ok set('CompUnit::Util','NativeCall','Test') ⊂ all-loaded()».short-name
+ok set('CompUnit::Util','NativeCall','Test') ⊂ all-loaded()».short-name,
 "all-loaded finds the correct units";
 
 my $cu = load('CompUnit::Util');

--- a/t/01-utils.t
+++ b/t/01-utils.t
@@ -11,7 +11,7 @@ ok find-loaded('CompUnit::Util') ~~ CompUnit:D, 'found CompUnit::Util';
 nok find-loaded('Foo'),'find-loaded on non-existent module returns false';
 ok find-loaded('Foo') ~~ Failure:D,'returns Failure';
 
-ok all-loaded()».short-name ~~ set('CompUnit::Util','NativeCall','Test'),
+ok set('CompUnit::Util','NativeCall','Test') ⊂ all-loaded()».short-name
 "all-loaded finds the correct units";
 
 my $cu = load('CompUnit::Util');


### PR DESCRIPTION
Currently running the test like `raku -MCompUnit::Repository::Staging -I. t/01-utils.t` fails.

 This PR fixes this issue by allowing the test to succeed when the user is loading other modules during test (eg. installing the distribution to a `CUR::Staging` repository and use that repo to test it before installing it to destination repository like `site`)